### PR TITLE
Feature/dim office

### DIFF
--- a/dbt/models/marts/politics/territorialization/dimensions/dim_office.sql
+++ b/dbt/models/marts/politics/territorialization/dimensions/dim_office.sql
@@ -1,0 +1,35 @@
+{{ 
+  config(
+    materialized = 'table'
+  ) 
+}}
+
+with source as (
+
+    select
+        office_id,
+        office_name
+    from {{ ref('stg_tse__office') }}
+
+),
+
+deduplicated as (
+
+    select
+        {{ dbt_utils.generate_surrogate_key(['office_id']) }} as office_key,
+        office_id,
+        office_name,
+        row_number() over (
+            partition by office_id
+            order by office_name
+        ) as rn
+    from source
+
+)
+
+select
+    office_key,
+    office_id,
+    office_name
+from deduplicated
+where rn = 1

--- a/dbt/models/marts/politics/territorialization/schema.yml
+++ b/dbt/models/marts/politics/territorialization/schema.yml
@@ -215,3 +215,14 @@ models:
             - party_id
             - coalition_name
             - coalition_decomp
+  
+  
+  - name: dim_office
+    description: "Dimensão canônica de cargos eletivos."
+    columns:
+        - name: office_key
+          tests: [unique, not_null]
+        - name: office_id
+          tests: [unique, not_null]
+        - name: office_name
+          tests: [not_null]

--- a/dbt/models/staging/politics/territorialization/stg_tse__office.sql
+++ b/dbt/models/staging/politics/territorialization/stg_tse__office.sql
@@ -1,0 +1,19 @@
+with source as (
+
+    select *
+        from {{ source('tse', 'tse_votacao_nominal_municipio_zona') }}
+
+),
+
+renamed as (
+
+    select distinct
+            safe_cast(cd_cargo as int64)                    as office_id,
+            safe_cast(ds_cargo as string)                   as office_name
+
+    from source
+
+)
+
+select *
+from renamed


### PR DESCRIPTION
Este PR cria a dimensão dim_office, responsável por padronizar os cargos eletivos no modelo de dados.

A fonte fornece um identificador estável e único (cd_cargo), o que permite que a dimensão seja simples, canônica e sem necessidade de histórico.

🧱 O que foi implementado

Nova dimensão: dim_office

Materialização como tabela

Utiliza:

cd_cargo como chave natural

office_key como chave substituta (hash)

Estrutura mínima e intencional:

office_key

office_id

office_name

Deduplicação defensiva para garantir 1 linha por cd_cargo

Documentação e testes em YAML

🎯 Grain

1 linha por cargo eletivo (cd_cargo)

🧪 Testes

office_key: unique, not_null

office_id: unique, not_null

office_name: not_null

Todos os testes do dbt estão passando.

✅ Resultado

Dimensão estável, simples e reutilizável, alinhada aos padrões atuais do projeto e pronta para integração futura com as tabelas fato.

Close #18 