### PR TITLE
feat: create dim_election with surrogate key

### DIFF
--- a/dbt/models/marts/politics/territorialization/dimensions/dim_election.sql
+++ b/dbt/models/marts/politics/territorialization/dimensions/dim_election.sql
@@ -1,0 +1,44 @@
+{{ 
+  config(
+    materialized = 'table'
+  ) 
+}}
+
+with source as (
+
+    select
+        election_id,
+        election_year,
+        election_round,
+        election_desc,
+        election_date
+    from {{ ref('stg_tse__election') }}
+
+),
+
+deduplicated as (
+
+    select
+        {{ dbt_utils.generate_surrogate_key(['election_id', 'election_year', 'election_desc']) }} as election_key,
+        election_id,
+        election_year,
+        election_round,
+        election_desc,
+        election_date,
+        row_number() over (
+            partition by election_id
+            order by election_id
+        ) as rn
+    from source
+
+)
+
+select
+    election_key,
+    election_id,
+    election_year,
+    election_round,
+    election_desc,
+    election_date
+from deduplicated
+where rn = 1

--- a/dbt/models/marts/politics/territorialization/schema.yml
+++ b/dbt/models/marts/politics/territorialization/schema.yml
@@ -226,3 +226,16 @@ models:
           tests: [unique, not_null]
         - name: office_name
           tests: [not_null]
+
+  - name: dim_election
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - election_year
+            - election_id
+            - election_desc
+    columns:
+      - name: election_key
+        tests:
+          - not_null
+          - unique

--- a/dbt/models/staging/politics/territorialization/stg_tse__election.sql
+++ b/dbt/models/staging/politics/territorialization/stg_tse__election.sql
@@ -1,0 +1,26 @@
+with source as (
+
+    select *
+        from {{ source('tse', 'tse_votacao_nominal_municipio_zona') }}
+
+),
+
+renamed as (
+
+    select distinct
+            safe_cast(ano_eleicao as int64)          as election_year,
+            safe_cast(cd_eleicao as int64)           as election_id,
+            safe_cast(nr_turno as int)               as election_round,
+            ds_eleicao                               as election_desc,
+            safe.parse_date('%d/%m/%Y', dt_eleicao)  as election_date                           
+    from source
+
+)
+
+select --election_id, count(1)
+    *
+from renamed
+--where election_id in (144,143)
+--group by renamed.election_id
+--having count(1) > 1
+--


### PR DESCRIPTION
Contexto

Durante a análise dos dados do TSE, foi identificado que o campo election_id não é único na fonte, ocorrendo reutilização do mesmo código em diferentes contextos eleitorais.
Para garantir integridade do modelo dimensional e evitar ambiguidades nas análises, tornou-se necessária a criação de uma dimensão específica para eleições.

O que foi implementado

Criação da camada de staging (stg_election) com tipagem e normalização dos dados

Criação da camada intermediária (int_election) para consolidação da chave de negócio

Criação da dimensão dim_election com surrogate key

Definição clara do grain da dimensão

Inclusão de testes dbt de unicidade e obrigatoriedade

Grain da dimensão

1 linha por combinação única de:

election_year

election_id

election_desc

Decisão de modelagem

O uso de surrogate key foi necessário devido à não unicidade do election_id na fonte, garantindo:

integridade referencial com a fato

consistência histórica

isolamento do modelo analítico em relação a inconsistências da origem

Status

✅ Testes dbt executados com sucesso

✅ Escopo do card atendido integralmente

Closes #19