### PR TITLE
feature: create dim_candidate with surrogate key

### DIFF
--- a/dbt/models/marts/politics/territorialization/dimensions/dim_candidate.sql
+++ b/dbt/models/marts/politics/territorialization/dimensions/dim_candidate.sql
@@ -1,0 +1,53 @@
+{{ 
+  config(
+    materialized = 'table'
+  ) 
+}}
+
+with source as (
+
+    select
+            election_year,	
+            election_id,
+            candidate_id,
+            candidate_name,
+            candidate_ballot_name,
+            party_id,
+            party_acr,
+            office_id,
+    from {{ ref('stg_tse__candidato') }}
+
+),
+
+deduplicated as (
+
+    select
+        {{ dbt_utils.generate_surrogate_key(['election_id', 'election_year', 'candidate_id', 'party_id','office_id']) }} as candidate_key,
+            election_year,
+            election_id,
+            candidate_id,
+            candidate_name,
+            candidate_ballot_name,
+            party_id,
+            party_acr,
+            office_id,
+        row_number() over (
+            partition by candidate_id, election_id, election_year, party_id, office_id
+            order by candidate_id
+        ) as rn
+    from source
+
+)
+
+select
+    candidate_key,
+    candidate_id,
+    election_id,
+    election_year,
+    candidate_name,
+    candidate_ballot_name,
+    party_id,
+    party_acr,
+    office_id
+from deduplicated
+where rn = 1

--- a/dbt/models/marts/politics/territorialization/schema.yml
+++ b/dbt/models/marts/politics/territorialization/schema.yml
@@ -195,16 +195,11 @@ models:
                 - Coligação
                 - Partido Isolado
                 - Federação
-
-
       - name: federation_id
         description: Identificador da federação, quando aplicável.
-
       - name: federation_name
         description: Nome da federação, quando aplicável.
-
     tests:
-
       - dbt_utils.unique_combination_of_columns:
           name: uq_dim_coalizao_partido_grain
           combination_of_columns:
@@ -215,7 +210,6 @@ models:
             - party_id
             - coalition_name
             - coalition_decomp
-  
   
   - name: dim_office
     description: "Dimensão canônica de cargos eletivos."
@@ -239,3 +233,40 @@ models:
         tests:
           - not_null
           - unique
+
+  - name: dim_candidate
+    description: >
+      Dimensão de candidatos.
+      Grain: uma linha por candidato por eleição.
+
+    columns:
+      - name: candidate_key
+        description: Chave substituta da dimensão de candidatos.
+        tests:
+          - not_null
+          - unique
+
+      - name: election_year
+        description: Ano da eleição.
+        tests:
+          - not_null
+
+      - name: election_id
+        description: Identificador da eleição.
+        tests:
+          - not_null
+
+      - name: candidate_id
+        description: Identificador do candidato no TSE.
+        tests:
+          - not_null
+
+      - name: party_id
+        description: Identificador do partido do candidato na eleição.
+        tests:
+          - not_null
+
+      - name: office_id
+        description: Código do cargo disputado.
+        tests:
+          - not_null

--- a/dbt/models/staging/politics/territorialization/stg_tse__candidato.sql
+++ b/dbt/models/staging/politics/territorialization/stg_tse__candidato.sql
@@ -7,16 +7,15 @@ with source as (
 
 renamed as (
 
-    select
+    select distinct
         SAFE_CAST(ANO_ELEICAO as int)       as election_year,
+        SAFE_CAST(CD_ELEICAO as int64)      as election_id,
         SAFE_CAST(SQ_CANDIDATO as string)   as candidate_id,
         SAFE_CAST(NM_CANDIDATO as string)   as candidate_name,
-        SAFE_CAST(NR_CANDIDATO as int)      as candidate_number,
+        NM_URNA_CANDIDATO                   as candidate_ballot_name,
         SAFE_CAST(NR_PARTIDO as int)        as party_id,
-        SAFE_CAST(SG_PARTIDO as string)     as party_acr,
-        SAFE_CAST(SG_UF as string)       as state_abbreviation,
+        SAFE_CAST(SG_PARTIDO as string)     as party_acr, --Existe só pra faciliar a leitura
         SAFE_CAST(CD_CARGO as int)          as office_id
-
     from source
 )
 


### PR DESCRIPTION
Este PR implementa a dimensão dim_candidate, modelada no nível de candidatura por eleição, conforme definido no escopo da Sprint 3.

🎯 Objetivo

Disponibilizar uma dimensão de candidatos adequada para análises eleitorais, respeitando as regras do domínio do TSE, onde:

um candidato concorre a apenas um cargo por eleição;

um candidato concorre por apenas um partido por eleição.

🧠 Decisões de modelagem

A dimensão representa a candidatura, não o candidato como entidade global.

O grain da tabela é:

1 linha por candidato por eleição

election_id e election_year fazem parte da identidade do registro.

Partido e cargo são atributos da candidatura e, portanto, pertencem à dimensão.

Coligação não foi incluída na dim_candidate, pois é contextual ao evento eleitoral e será tratada na fato.

🧩 Principais campos

candidate_sk (chave substituta)

candidate_id

election_id

election_year

party_id

office_id

candidate_name

candidate_ballot_name

🧪 Testes

unique e not_null na chave substituta

not_null para atributos obrigatórios

Todos os testes passaram com sucesso ✅

✅ Status

Escopo do Card #20 atendido

Modelagem alinhada ao domínio eleitoral

PR pronto para merge 🚀

Close #20 