### PR TITLE
Sprint 4 — Finalização e documentação do modelo analítico eleitoral

### DIFF
--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -36,6 +36,8 @@ models:
       +materialized: view
     marts:
       +materialized: table
+    int:
+      +materialized: table
 
 packages:
   - package: dbt-labs/dbt_utils

--- a/dbt/models/marts/politics/territorialization/dimensions/dim_election.sql
+++ b/dbt/models/marts/politics/territorialization/dimensions/dim_election.sql
@@ -19,14 +19,14 @@ with source as (
 deduplicated as (
 
     select
-        {{ dbt_utils.generate_surrogate_key(['election_id', 'election_year', 'election_desc']) }} as election_key,
+        {{ dbt_utils.generate_surrogate_key(['election_year','election_id','election_round', 'election_desc']) }} as election_key,
         election_id,
         election_year,
         election_round,
         election_desc,
         election_date,
         row_number() over (
-            partition by election_id
+            partition by election_year,election_id,election_round, election_desc
             order by election_id
         ) as rn
     from source

--- a/dbt/models/marts/politics/territorialization/facts/fct_votacao_nominal.sql
+++ b/dbt/models/marts/politics/territorialization/facts/fct_votacao_nominal.sql
@@ -1,84 +1,9 @@
-with base as (
+with source as (
 
     select
-         state_abbreviation
-        ,municipality_id
-        ,zone_number
+            *
+    from {{ ref('int_votacao_nominal') }}
 
-        ,candidate_id
-        ,office_id
-        ,party_acr
-                
-        ,election_year
-        ,election_round
-
-        ,qty_votes
-        ,qty_valid_votes
-
-    from {{ ref('stg_tse__votacao_nominal') }}
-
-    where zone_number is not null
-
-),
-
-territory as (
-
-    select
-        territory_sk,
-        state_abbreviation,
-        municipality_id,
-        zone_number
-    from {{ ref('dim_territory') }}
-
-),
-
-final as (
-
-    select
-        t.territory_sk,
-
-        {{ dbt_utils.generate_surrogate_key([
-            'b.candidate_id',
-            'b.party_acr'
-        ]) }}                     as candidate_sk,
-
-        {{ dbt_utils.generate_surrogate_key([
-            'b.party_acr'
-        ]) }}                     as party_sk,
-
-        {{ dbt_utils.generate_surrogate_key([
-            'b.office_id'
-        ]) }}                     as office_sk,
-
-        {{ dbt_utils.generate_surrogate_key([
-            'b.election_year',
-            'b.election_round'
-        ]) }}                     as election_sk,
-
-        b.qty_votes,
-        b.qty_valid_votes,
-        current_timestamp()       as ingested_at
-    from base b
-    join territory t
-      on b.state_abbreviation = t.state_abbreviation
-     and b.municipality_id = t.municipality_id
-     and b.zone_number = t.zone_number
 
 )
-
-select
-    territory_sk,
-    candidate_sk,
-    party_sk,
-    office_sk,
-    election_sk,
-    sum(qty_votes)        as qty_votes,
-    sum(qty_valid_votes) as qty_valid_votes,
-    max(current_timestamp()) as ingested_at
- from final
-group by
-    territory_sk,
-    candidate_sk,
-    party_sk,
-    office_sk,
-    election_sk
+select * from source

--- a/dbt/models/marts/politics/territorialization/facts/int_votacao_nominal.sql
+++ b/dbt/models/marts/politics/territorialization/facts/int_votacao_nominal.sql
@@ -1,0 +1,64 @@
+{{ config(materialized='table') }}
+
+with source as (
+
+    select *
+    from {{ ref('stg_tse__votacao_nominal') }}
+
+),
+
+final as (
+
+    select
+        ----------------------------------------------------------------------
+        -- SURROGATE KEYS (espelhando exatamente as dimensões)
+        ----------------------------------------------------------------------
+
+        {{ dbt_utils.generate_surrogate_key([
+            'source.election_year',
+            'source.election_id',
+            'source.election_round',
+            'source.election_desc'
+        ]) }}                                   as election_key,
+
+        {{ dbt_utils.generate_surrogate_key([
+            'source.election_id', 
+            'source.election_year', 
+            'source.candidate_id', 
+            'source.party_id',
+            'source.office_id'
+        ]) }}                                   as candidate_key,
+
+        {{ dbt_utils.generate_surrogate_key([
+            'source.office_id'
+        ]) }}                                   as office_key,
+
+        {{ dbt_utils.generate_surrogate_key([
+            'source.election_year',
+            'source.election_round',
+            'source.state_abbreviation',
+            'source.coalition_id',
+            'source.party_id',
+            'source.coligation_name',
+            'source.coligation_decomp'
+        ]) }}                                   as coalition_key,
+
+        {{ dbt_utils.generate_surrogate_key([
+        'state_abbreviation',
+        'municipality_id',
+        'zone_number'
+        ]) }}            as territory_key,
+
+        ----------------------------------------------------------------------
+        -- MÉTRICAS
+        ----------------------------------------------------------------------
+
+        source.qty_votes               as qty_nominal_votes,
+        source.qty_valid_votes         as qty_valid_votes
+
+    from source
+
+)
+
+select *
+from final

--- a/dbt/models/marts/politics/territorialization/schema.yml
+++ b/dbt/models/marts/politics/territorialization/schema.yml
@@ -21,35 +21,7 @@ models:
       - name: zone_number
         tests:
           - not_null
-
-  - name: fct_votacao_nominal
-    description: Fact table for nominal votes by candidate and zone.
-
-    columns:
-      - name: territory_sk
-        tests:
-          - not_null
-
-      - name: candidate_sk
-        tests:
-          - not_null
-
-      - name: party_sk
-        tests:
-          - not_null
-
-      - name: office_sk
-        tests:
-          - not_null
-
-      - name: election_sk
-        tests:
-          - not_null
-
-      - name: qty_votes
-        tests:
-          - not_null
-
+  
   - name: dim_party
     description: >
       Dimensão de partidos políticos (TSE),
@@ -268,5 +240,60 @@ models:
 
       - name: office_id
         description: Código do cargo disputado.
+        tests:
+          - not_null
+
+  - name: fct_votacao_nominal
+    description: >
+      Fato de votação nominal consolidada, no nível de
+      eleição, candidato, cargo, coligação e território.
+
+    columns:
+      - name: election_key
+        description: FK para dim_election
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_election')
+              field: election_key
+
+      - name: candidate_key
+        description: FK para dim_candidate
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_candidate')
+              field: candidate_key
+
+      - name: office_key
+        description: FK para dim_office
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_office')
+              field: office_key
+
+      - name: coalition_key
+        description: FK para dim_party_coalition
+        tests:
+          - relationships:
+              to: ref('dim_party_coalition')
+              field: coalizao_partido_sk
+
+      - name: territory_key
+        description: FK para dim_territory
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_territory')
+              field: territory_sk
+
+      - name: qty_nominal_votes
+        description: Quantidade de votos nominais
+        tests:
+          - not_null
+
+      - name: qty_valid_votes
+        description: Quantidade de votos válidos
         tests:
           - not_null

--- a/dbt/models/staging/politics/territorialization/stg_tse__candidato.sql
+++ b/dbt/models/staging/politics/territorialization/stg_tse__candidato.sql
@@ -10,7 +10,7 @@ renamed as (
     select distinct
         SAFE_CAST(ANO_ELEICAO as int)       as election_year,
         SAFE_CAST(CD_ELEICAO as int64)      as election_id,
-        SAFE_CAST(SQ_CANDIDATO as string)   as candidate_id,
+        SAFE_CAST(SQ_CANDIDATO as int64)   as candidate_id,
         SAFE_CAST(NM_CANDIDATO as string)   as candidate_name,
         NM_URNA_CANDIDATO                   as candidate_ballot_name,
         SAFE_CAST(NR_PARTIDO as int)        as party_id,

--- a/dbt/models/staging/politics/territorialization/stg_tse__election.sql
+++ b/dbt/models/staging/politics/territorialization/stg_tse__election.sql
@@ -7,20 +7,15 @@ with source as (
 
 renamed as (
 
-    select distinct
-            safe_cast(ano_eleicao as int64)          as election_year,
-            safe_cast(cd_eleicao as int64)           as election_id,
-            safe_cast(nr_turno as int)               as election_round,
-            ds_eleicao                               as election_desc,
-            safe.parse_date('%d/%m/%Y', dt_eleicao)  as election_date                           
+    select  SAFE_CAST(ANO_ELEICAO AS INT64)             AS election_year,
+		SAFE_CAST(CD_ELEICAO AS INT64)					AS election_id,
+		SAFE_CAST(NR_TURNO AS INT64)                    AS election_round,
+		lower(trim(ds_eleicao))         				AS election_desc,
+		SAFE.PARSE_DATE('%d/%m/%Y', DT_ELEICAO)		    AS election_date
     from source
 
 )
 
-select --election_id, count(1)
+select
     *
 from renamed
---where election_id in (144,143)
---group by renamed.election_id
---having count(1) > 1
---

--- a/dbt/models/staging/politics/territorialization/stg_tse__votacao_nominal.sql
+++ b/dbt/models/staging/politics/territorialization/stg_tse__votacao_nominal.sql
@@ -9,11 +9,11 @@ renamed as (
 
     select
         SAFE_CAST(ANO_ELEICAO AS INT64)                 AS election_year,
-		SAFE_CAST(CD_ELEICAO AS INT64)					AS election_cod,
-		DS_ELEICAO										AS election_desc,
-		SAFE.PARSE_DATE('%d/%m/%Y', DT_ELEICAO)		    AS election_date,
+		SAFE_CAST(CD_ELEICAO AS INT64)					AS election_id,
 		SAFE_CAST(NR_TURNO AS INT64)                    AS election_round,
-        SAFE_CAST(CD_MUNICIPIO AS INT64)             	AS municipality_id,
+		lower(trim(ds_eleicao))         				AS election_desc,
+		SAFE.PARSE_DATE('%d/%m/%Y', DT_ELEICAO)		    AS election_date,
+		SAFE_CAST(CD_MUNICIPIO AS INT64)             	AS municipality_id,
         NM_MUNICIPIO              						AS municipality_name,
 		SAFE_CAST(NR_ZONA AS INT64)                     AS zone_number,
         SAFE_CAST(SQ_CANDIDATO AS INT64)                AS candidate_id,
@@ -21,21 +21,28 @@ renamed as (
         NM_CANDIDATO              					    AS candidate_name,
         NM_SOCIAL_CANDIDATO							    AS candidate_social_name,
         COALESCE(NM_URNA_CANDIDATO, 'Não informado')    AS candidate_ballot_name,
-		SAFE_CAST(QT_VOTOS_NOMINAIS AS INT64) 		    AS qty_votes,
-		SAFE_CAST(QT_VOTOS_NOMINAIS_VALIDOS AS INT64)   AS qty_valid_votes,
+		COALESCE(SAFE_CAST(QT_VOTOS_NOMINAIS AS INT64), 0) 		    AS qty_votes,
+		COALESCE(SAFE_CAST(QT_VOTOS_NOMINAIS_VALIDOS AS INT64), 0)   AS qty_valid_votes,
 	    SG_UF								            AS state_abbreviation,
 		SAFE_CAST(NR_PARTIDO AS INT64)		    		AS party_id,
 		SG_PARTIDO										AS party_acr,
 		NM_PARTIDO                  					AS party_name,
-		cd_cargo										AS office_id,
+		SAFE_CAST(CD_CARGO AS INT64)					AS office_id,
 		ds_cargo										AS office_name,
+		SAFE_CAST(SQ_COLIGACAO AS INT64)				AS coalition_id,
+		NM_COLIGACAO									AS coalition_name,
+		DS_COMPOSICAO_COLIGACAO					    	AS coalition_decomp,
+		        case
+            when nm_coligacao = 'FEDERAÇÃO' then null
+            when nm_coligacao = 'PARTIDO ISOLADO' then 'Partido Isolado'
+            else nm_coligacao
+        end                                            as coligation_name,
+
+        ds_composicao_coligacao                        as coligation_decomp,
 		SAFE_CAST(NR_FEDERACAO AS INT64)				AS federation_id,
 		NM_FEDERACAO									AS federation_name,
 		SG_FEDERACAO									AS federation_acr,
 		DS_COMPOSICAO_FEDERACAO							AS federation_decomp,
-		SAFE_CAST(SQ_COLIGACAO AS INT64)				AS federation_sq,
-		NM_COLIGACAO									AS coligation_name,
-		DS_COMPOSICAO_COLIGACAO					    	AS coligation_decomp,
         current_timestamp()               				AS ingested_at
     from source
 


### PR DESCRIPTION
🧾 Descrição

Este PR consolida e encerra a Sprint 4, reunindo os últimos ajustes e a documentação final do modelo analítico eleitoral.

Durante a sprint, foram entregues:

Modelagem e validação dos fatos eleitorais

Integração completa com dimensões e bridges

Documentação do grain e das decisões de modelagem

Atualização dos schema.yml com descrições claras

Testes dbt 100% verdes

Com isso, o modelo encontra-se pronto para consumo analítico, com estrutura clara, documentada e extensível para próximas sprints.

🎯 Destaques

Grain do fato explicitamente documentado

Dimensões, bridges e intermediários descritos e contextualizados

Padrões de modelagem consistentes com o DW

Nenhuma pendência técnica conhecida

✅ Checklist

 Todos os cards da Sprint 4 concluídos

 Testes dbt passando (100% green)

 Documentação revisada e atualizada

 Sprint pronta para encerramento

🔗 Issues relacionadas

Closes #31
Closes #29 
Closes #30 
