### PR TITLE
Reestruturar a documentação como uma plataforma de dados orientada a produto

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,105 +2,60 @@
 
 🇧🇷 Read in Portuguese: [README.pt-br.md](README.pt-br.md)
 
+Personal data platform designed as a long-lived analytical product, not a demo.
 
-Personal data platform for lifelong analytics: pipelines, dbt models, NSA/SNA, NLP, LLMs, dashboards, and experimentation.
+This repository represents the backbone of my personal data platform, built to support scalable, versioned, and low-cost analytics over time.
+Its core focus is data engineering and analytical modeling, with domain-driven analytical products built on top of a consistent data lake and dbt-based warehouse.
 
-This repository is the backbone of my personal data platform, bringing together data ingestion pipelines, analytical modeling with dbt, social and social network analysis (NSA/SNA), natural language processing (NLP), dashboards, and exploratory experiments.
+As a concrete example of this platform in action, the repository includes a complete analytical data warehouse built from public CSV data: ingestion, loading, transformation with dbt, and visualization through Looker Studio.
+Although intentionally simple (one fact table and a small set of dimensions), this warehouse represents a fully functional, end-to-end analytical product.
 
-## Main structure
+## How to navigate this repository
 
-- **data-lake/** – raw, refined, and curated data (raw → bronze → silver → gold)
-- **dbt/** – dbt models for transformations and semantic data warehouse
-- **analytics/** – domain-oriented analytical projects
-- **notebooks/** – exploratory notebooks (NSA, NLP, experiments)
-- **scripts/** – ingestion, transformation, and utility scripts
+This repository is organized as a long-lived analytical platform, composed of three clearly separated layers: platform foundation, analytical products, and experimentation.
+
+If you are visiting this repository for the first time, the recommended reading path is:
+
+1. **Platform overview (this README)**
+2. **Platform foundation**
+   - `data-lake/`
+   - `scripts/ingestion/`
+3. **Analytical foundation (Data Warehouse)**
+   - `dbt/`
+4. **Delivered analytical product**
+   - `analytics/politics/party-territorialization/`
+5. **Domain-oriented analytics**
+   - `analytics/`
+6. **Experiments and research**
+   - `notebooks/`, `analytics/experiments/`
 
 ## Goals
 
-1. Build a scalable, versioned, and low-cost **data lake**
-2. Create reliable **pipelines and analytical transformations** with dbt
-3. Perform **social network analysis (NSA/SNA)** on voting data and political patterns
-4. Apply **NLP** to political speeches and other textual data
-5. Explore **LLMs** in analytical and experimental contexts
-6. Visualize results through **dashboards**
-7. Maintain a long-term **data laboratory** for future projects and research
+### Platform (core)
+1. Build a scalable, versioned, and low-cost data lake
+2. Create reliable pipelines and analytical transformations using dbt
+3. Maintain a consistent analytical foundation, validated by a delivered end-to-end data warehouse
 
-## Technologies
+### Analytical products
+4. Perform social network analysis (NSA/SNA) on voting data and political patterns
+5. Apply NLP to political speeches and other textual datasets
+6. Visualize analytical results through dashboards and domain-oriented views
 
-- Git + GitHub (version control and governance)
-- Google Cloud Platform (Cloud Storage, BigQuery)
-- dbt (transformations, tests, and documentation)
-- Python (ETL, NLP, NSA/SNA)
-- Looker Studio / Power BI (dashboards and visualization)
+### Exploration and experimentation
+7. Explore LLMs in analytical and experimental contexts, grounded in real data
+8. Maintain a long-term data laboratory for future projects and research
 
-## Repository structure
-```
-roma9-data-platform
-├─ analytics
-│  ├─ experiments
-│  ├─ music
-│  ├─ nlp
-│  ├─ nsa
-│  └─ politics
-│     └─ party-territorialization
-│        └─ README.md
-├─ CONTRIBUTING.md
-├─ data-lake
-│  ├─ bronze
-│  ├─ gold
-│  ├─ raw
-│  │  └─ README.md
-│  └─ silver
-├─ dbt
-│  ├─ analyses
-│  ├─ dbt_project.yml
-│  ├─ macros
-│  ├─ models
-│  │  ├─ common
-│  │  ├─ marts
-│  │  │  ├─ music
-│  │  │  ├─ nlp
-│  │  │  ├─ nsa
-│  │  │  └─ politics
-│  │  │     └─ territorialization
-│  │  │        ├─ dimensions
-│  │  │        │  └─ dim_territory.sql
-│  │  │        ├─ facts
-│  │  │        │  └─ fct_votacao_nominal.sql
-│  │  │        └─ schema.yml
-│  │  └─ staging
-│  │     ├─ politics
-│  │     │  └─ territorialization
-│  │     │     ├─ stg_tse__votacao_nominal.sql
-│  │     │     ├─ stg_tse__votacao_nominal.yml
-│  │     │     └─ _tse__sources.yml
-│  │     └─ stg__healthcheck.sql
-│  ├─ package-lock.yml
-│  ├─ packages.yml
-│  ├─ README.md
-│  ├─ seeds
-│  ├─ snapshots
-│  └─ tests
-├─ LICENSE
-├─ logs
-├─ notebooks
-│  ├─ nlp
-│  └─ nsa
-├─ README.md
-└─ scripts
-   ├─ ingestion
-   │  ├─ politics
-   │  │  └─ territorialization
-   │  │     ├─ infer_schema_tse.py
-   │  │     ├─ load_tse_votacao_nominal.py
-   │  │     ├─ load_tse_votacao_nominal_bq.py
-   │  │     ├─ load_tse_votacao_nominal_create_table_postgres.py
-   │  │     ├─ load_tse_votacao_nominal_create_table_raw_bigquery.sql
-   │  │     ├─ load_tse_votacao_nominal_local_csv_postgres.py
-   │  │     └─ schema_tse_votacao_nominal.json
-   │  └─ README.md
-   ├─ transform
-   └─ utils
-      └─ CREATE_SCHEMA_POSTGRES.sql
+## Current state & roadmap
 
-```
+### Current state
+- Layered data lake
+- Reproducible ingestion from public CSV sources
+- Dimensional data warehouse modeled with dbt
+- At least one delivered domain-oriented analytical product
+- Dashboards validating end-to-end coherence
+
+### Roadmap
+- Expand the warehouse with additional domain-specific marts
+- Evolve products with new facts, dimensions, and metrics
+- Improve data quality, documentation, and testing
+- Explore advanced analytical use cases (NSA, NLP, LLMs) grounded in the platform

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -1,110 +1,59 @@
-
----
-
-## 📄 `README.pt-br.md` (Português)
-
-```md
 # roma9-data-platform
 
-Plataforma pessoal de dados para análises de longo prazo: pipelines, modelos dbt, NSA/SNA, NLP, LLMs, dashboards e experimentação.
+Personal data platform projetada como um produto analítico de longo prazo, não como uma demo.
 
-Este repositório é a espinha dorsal da minha plataforma pessoal de dados, reunindo pipelines de ingestão, modelagem analítica com dbt, análises sociais e de redes sociais (NSA/SNA), processamento de linguagem natural (NLP), dashboards e experimentos exploratórios.
+Este repositório representa a espinha dorsal da minha plataforma pessoal de dados, construída para suportar análises escaláveis, versionadas e de baixo custo ao longo do tempo.
+Seu foco principal é engenharia de dados e modelagem analítica, com produtos analíticos orientados a domínio construídos sobre um data lake consistente e um data warehouse com dbt.
 
-## Estrutura principal
+Como exemplo concreto da plataforma em funcionamento, o repositório inclui um data warehouse analítico completo construído a partir de dados públicos em CSV: ingestão, carga, transformação com dbt e visualização no Looker Studio.
+Embora intencionalmente simples (uma tabela fato e um pequeno conjunto de dimensões), esse warehouse representa um produto analítico ponta a ponta totalmente funcional.
 
-- **data-lake/** – dados brutos, refinados e curados (raw → bronze → silver → gold)
-- **dbt/** – modelos dbt para transformações e data warehouse semântico
-- **analytics/** – análises organizadas por domínio
-- **notebooks/** – notebooks exploratórios (NSA, NLP, experimentos)
-- **scripts/** – scripts de ingestão, transformação e utilitários
+## Como navegar neste repositório
+
+Este repositório é organizado como uma plataforma analítica de longo prazo, composta por três camadas bem definidas: fundação da plataforma, produtos analíticos e experimentação.
+
+Para quem está visitando o projeto pela primeira vez, o caminho de leitura recomendado é:
+
+1. **Visão geral da plataforma (este README)**
+2. **Fundação da plataforma**
+   - `data-lake/`
+   - `scripts/ingestion/`
+3. **Fundação analítica (Data Warehouse)**
+   - `dbt/`
+4. **Produto analítico entregue**
+   - `analytics/politics/party-territorialization/`
+5. **Análises orientadas a domínio**
+   - `analytics/`
+6. **Experimentos e pesquisa**
+   - `notebooks/`, `analytics/experiments/`
 
 ## Objetivos
 
-1. Construir um **data lake** escalável, versionado e de baixo custo  
-2. Criar **pipelines e transformações analíticas** com dbt  
-3. Realizar **análises de redes sociais (NSA/SNA)** sobre votações e padrões políticos  
-4. Aplicar **NLP** em discursos políticos e outros textos  
-5. Explorar **LLMs** em contextos analíticos e experimentais  
-6. Visualizar resultados por meio de **dashboards**  
-7. Manter um **laboratório de dados** de longo prazo para projetos futuros  
+### Plataforma (core)
+1. Construir um data lake escalável, versionado e de baixo custo
+2. Criar pipelines confiáveis e transformações analíticas com dbt
+3. Manter uma fundação analítica consistente, validada por um data warehouse ponta a ponta entregue
 
-## Tecnologias
+### Produtos analíticos
+4. Realizar análises de redes sociais (NSA/SNA) sobre dados de votação e padrões políticos
+5. Aplicar NLP a discursos políticos e outros conjuntos textuais
+6. Visualizar resultados analíticos por meio de dashboards
 
-- Git + GitHub (versionamento e governança)
-- Google Cloud Platform (Cloud Storage, BigQuery)
-- dbt (transformações, testes e documentação)
-- Python (ETL, NLP, NSA/SNA)
-- Looker Studio / Power BI (visualização e dashboards)
+### Exploração e experimentação
+7. Explorar LLMs em contextos analíticos e experimentais, ancorados em dados reais
+8. Manter um laboratório de dados de longo prazo para projetos futuros e pesquisa
 
-## Estrutura do repositório
+## Estado atual e roadmap
 
-```
-roma9-data-platform
-├─ analytics
-│  ├─ experiments
-│  ├─ music
-│  ├─ nlp
-│  ├─ nsa
-│  └─ politics
-│     └─ party-territorialization
-│        └─ README.md
-├─ CONTRIBUTING.md
-├─ data-lake
-│  ├─ bronze
-│  ├─ gold
-│  ├─ raw
-│  │  └─ README.md
-│  └─ silver
-├─ dbt
-│  ├─ analyses
-│  ├─ dbt_project.yml
-│  ├─ macros
-│  ├─ models
-│  │  ├─ common
-│  │  ├─ marts
-│  │  │  ├─ music
-│  │  │  ├─ nlp
-│  │  │  ├─ nsa
-│  │  │  └─ politics
-│  │  │     └─ territorialization
-│  │  │        ├─ dimensions
-│  │  │        │  └─ dim_territory.sql
-│  │  │        ├─ facts
-│  │  │        │  └─ fct_votacao_nominal.sql
-│  │  │        └─ schema.yml
-│  │  └─ staging
-│  │     ├─ politics
-│  │     │  └─ territorialization
-│  │     │     ├─ stg_tse__votacao_nominal.sql
-│  │     │     ├─ stg_tse__votacao_nominal.yml
-│  │     │     └─ _tse__sources.yml
-│  │     └─ stg__healthcheck.sql
-│  ├─ package-lock.yml
-│  ├─ packages.yml
-│  ├─ README.md
-│  ├─ seeds
-│  ├─ snapshots
-│  └─ tests
-├─ LICENSE
-├─ logs
-├─ notebooks
-│  ├─ nlp
-│  └─ nsa
-├─ README.md
-└─ scripts
-   ├─ ingestion
-   │  ├─ politics
-   │  │  └─ territorialization
-   │  │     ├─ infer_schema_tse.py
-   │  │     ├─ load_tse_votacao_nominal.py
-   │  │     ├─ load_tse_votacao_nominal_bq.py
-   │  │     ├─ load_tse_votacao_nominal_create_table_postgres.py
-   │  │     ├─ load_tse_votacao_nominal_create_table_raw_bigquery.sql
-   │  │     ├─ load_tse_votacao_nominal_local_csv_postgres.py
-   │  │     └─ schema_tse_votacao_nominal.json
-   │  └─ README.md
-   ├─ transform
-   └─ utils
-      └─ CREATE_SCHEMA_POSTGRES.sql
+### Estado atual
+- Data lake em camadas
+- Ingestão reproduzível a partir de CSVs públicos
+- Data warehouse dimensional modelado com dbt
+- Pelo menos um produto analítico orientado a domínio já entregue
+- Dashboards validando a coerência ponta a ponta
 
-```
+### Roadmap
+- Expandir o warehouse com novos marts orientados a domínio
+- Evoluir produtos com novos fatos, dimensões e métricas
+- Aprimorar qualidade de dados, documentação e testes
+- Explorar casos analíticos avançados (NSA, NLP, LLMs) ancorados na plataforma

--- a/analytics/politics/party-territorialization/README.md
+++ b/analytics/politics/party-territorialization/README.md
@@ -1,68 +1,12 @@
-# Party Territorialization and Fragmentation in Brazil
+This directory contains a domain-oriented analytical product built on top of the Roma9 Data Platform.
 
-This project analyzes the territorial distribution of party competition in Brazil,
-focusing on the degree of party nationalization and territorial fragmentation
-in elections for the Federal Chamber of Deputies.
+The project focuses on party territorialization and voting behavior, using public electoral data to demonstrate how the platform supports end-to-end analytics: ingestion, dimensional modeling with dbt, analytical exploration, and visualization.
 
-The analysis covers the period from 2012 to 2024 and is based exclusively on
-official electoral data from the Brazilian Superior Electoral Court (TSE).
+While grounded in political science concepts, this project is primarily an exercise in applied data engineering and analytical modeling rather than an academic study.
 
-Status: MVP in progress
+## Role within the platform
+- Reference implementation of a dimensional data warehouse
+- Real-world use case for a domain-oriented analytical mart
+- Foundation for future analytical extensions (new facts, dimensions, and metrics)
 
-## Scope of analysis
-
-- Country: Brazil
-- Office: Federal Deputy (Deputado Federal)
-- Period: 2012–2024
-- Electoral level: State (UF)
-- Unit of analysis: Party × State × Election
-- Votes considered: Valid nominal votes, 1st round only
-
-## Raw data (TSE)
-
-The electoral data used in this project were obtained directly from the
-Brazilian Superior Electoral Court (Tribunal Superior Eleitoral – TSE).
-
-The source files consist of public CSV datasets containing vote counts
-at the candidate level, disaggregated by electoral zone and municipality.
-
-The raw data layer is treated as immutable and is preserved without any
-logical transformations to ensure auditability and reproducibility.
-
-- Source: TSE public electoral datasets
-- Format: CSV
-- Coverage: Elections from 2012 to 2024
-- Original granularity:
-  - Candidate
-  - Electoral zone
-  - Municipality
-  - Election year
-- Transformations applied: None
-
-## Data ingestion flow
-
-The ingestion process follows a canonical and reproducible workflow,
-independent of the initial exploratory implementation.
-
-1. Download public CSV files from the TSE website
-2. Store the original files in Cloud Storage
-3. Load the CSV files into BigQuery as raw tables
-4. Use the raw BigQuery dataset as the single source of truth
-   for all downstream analytical transformations
-
-
-## Raw layer principles
-
-- The raw dataset is immutable
-- No filtering, aggregation, or enrichment is performed at this stage
-- All analytical logic is applied only in downstream layers
-- The raw layer exists exclusively to preserve data fidelity
-
-```mermaid
-graph LR
-    TSE[TSE - Public CSV files]
-    GCS[Cloud Storage]
-    BQ_RAW[BigQuery - Raw dataset]
-
-    TSE --> GCS
-    GCS --> BQ_RAW
+The current scope is intentionally limited to a single fact table and a small set of dimensions, prioritizing correctness, clarity, and extensibility over volume.

--- a/analytics/politics/party-territorialization/README.pt-br.md
+++ b/analytics/politics/party-territorialization/README.pt-br.md
@@ -1,74 +1,12 @@
+Este diretório contém um produto analítico orientado a domínio, construído sobre a plataforma Roma9 Data Platform.
 
----
+O projeto analisa territorialização partidária e comportamento de votação, utilizando dados eleitorais públicos para demonstrar o uso da plataforma de ponta a ponta: ingestão, modelagem dimensional com dbt, exploração analítica e visualização.
 
-## 📄 `README.pt-br.md` (Português)
+Embora se apoie em conceitos da ciência política, este projeto é прежде de tudo um exercício de engenharia de dados e modelagem analítica aplicada, e não um estudo acadêmico.
 
+## Papel dentro da plataforma
+- Implementação de referência de um data warehouse dimensional
+- Caso real de um mart analítico orientado a domínio
+- Base para extensões analíticas futuras (novos fatos, dimensões e métricas)
 
-# Territorialização e Fragmentação Partidária no Brasil
-
-Este projeto analisa a distribuição territorial da competição partidária no Brasil,
-com foco no grau de nacionalização dos partidos e na fragmentação territorial
-nas eleições para a Câmara dos Deputados.
-
-A análise cobre o período de 2012 a 2024 e é baseada exclusivamente em
-dados eleitorais oficiais do Tribunal Superior Eleitoral (TSE).
-
-**Status:** MVP em desenvolvimento
-
-## Escopo da análise
-
-- País: Brasil
-- Cargo: Deputado Federal
-- Período: 2012–2024
-- Nível eleitoral: Unidade Federativa (UF)
-- Unidade de análise: Partido × UF × Eleição
-- Votos considerados: Votos nominais válidos, apenas 1º turno
-
-## Dados brutos (TSE)
-
-Os dados eleitorais utilizados neste projeto foram obtidos diretamente
-do Tribunal Superior Eleitoral (TSE).
-
-Os arquivos de origem consistem em conjuntos de dados públicos em formato CSV,
-contendo a contagem de votos no nível de candidato, desagregados por
-zona eleitoral e município.
-
-A camada de dados brutos é tratada como **imutável** e preservada sem
-qualquer transformação lógica, garantindo auditabilidade e reprodutibilidade.
-
-- Fonte: Conjuntos de dados eleitorais públicos do TSE
-- Formato: CSV
-- Cobertura: Eleições de 2012 a 2024
-- Granularidade original:
-  - Candidato
-  - Zona eleitoral
-  - Município
-  - Ano da eleição
-- Transformações aplicadas: Nenhuma
-
-## Fluxo de ingestão de dados
-
-O processo de ingestão segue um fluxo canônico e reproduzível,
-independente da implementação exploratória inicial.
-
-1. Download dos arquivos CSV públicos a partir do site do TSE
-2. Armazenamento dos arquivos originais no Cloud Storage
-3. Carga dos arquivos CSV no BigQuery como tabelas brutas
-4. Uso do dataset bruto do BigQuery como **fonte única da verdade**
-   para todas as transformações analíticas posteriores
-
-## Princípios da camada raw
-
-- O dataset raw é imutável
-- Nenhum filtro, agregação ou enriquecimento é aplicado nesta etapa
-- Toda a lógica analítica é aplicada apenas nas camadas downstream
-- A camada raw existe exclusivamente para preservar a fidelidade dos dados
-
-```mermaid
-graph LR
-    TSE[TSE - Arquivos CSV públicos]
-    GCS[Cloud Storage]
-    BQ_RAW[BigQuery - Dataset raw]
-
-    TSE --> GCS
-    GCS --> BQ_RAW
+O escopo atual é intencionalmente limitado a uma tabela fato e um pequeno conjunto de dimensões, priorizando correção, clareza e extensibilidade em vez de volume.

--- a/data-lake/README.md
+++ b/data-lake/README.md
@@ -1,0 +1,4 @@
+This directory represents the storage foundation of the Roma9 Data Platform.
+
+The data lake is organized in explicit layers (raw → bronze → silver → gold), designed to support versioned, low-cost, and reproducible analytics.
+It serves as the persistent backbone for all analytical products and experiments developed in the repository.

--- a/data-lake/README.pt-br.md
+++ b/data-lake/README.pt-br.md
@@ -1,0 +1,4 @@
+Este diretório representa a fundação de armazenamento da plataforma Roma9 Data Platform.
+
+O data lake é organizado em camadas explícitas (raw → bronze → silver → gold), com foco em versionamento, baixo custo e reprodutibilidade analítica.
+Ele funciona como a base persistente para todos os produtos analíticos e experimentos desenvolvidos no repositório.

--- a/data-lake/raw/README.md
+++ b/data-lake/raw/README.md
@@ -1,14 +1,3 @@
-# RAW Layer
+This directory contains raw datasets as ingested from their original sources, without analytical transformations.
 
-This directory documents the RAW layer of the data lake.
-
-The RAW layer contains original source data preserved in its original format,
-without filtering, aggregation, or business logic transformations.
-
-Physical storage:
-- Cloud Storage bucket: roma9-data-lake
-- Path example:
-  raw/tse/votacao_nominal_municipio_zona/
-
-The Git repository does not store raw data files. It documents the architecture
-and ingestion processes only.
+Raw data is preserved to ensure traceability, reproducibility, and the ability to reprocess downstream layers as modeling decisions evolve.

--- a/data-lake/raw/README.pt-br.md
+++ b/data-lake/raw/README.pt-br.md
@@ -1,0 +1,3 @@
+Este diretório contém os dados brutos exatamente como obtidos das fontes originais, sem transformações analíticas.
+
+A preservação dos dados raw garante rastreabilidade, reprocessamento e reprodutibilidade conforme as decisões de modelagem evoluem.

--- a/dbt/README.md
+++ b/dbt/README.md
@@ -1,15 +1,3 @@
-Welcome to your new dbt project!
+This directory contains the analytical modeling layer of the platform, implemented using dbt.
 
-### Using the starter project
-
-Try running the following commands:
-- dbt run
-- dbt test
-
-
-### Resources:
-- Learn more about dbt [in the docs](https://docs.getdbt.com/docs/introduction)
-- Check out [Discourse](https://discourse.getdbt.com/) for commonly asked questions and answers
-- Join the [chat](https://community.getdbt.com/) on Slack for live discussions and support
-- Find [dbt events](https://events.getdbt.com) near you
-- Check out [the blog](https://blog.getdbt.com/) for the latest news on dbt's development and best practices
+The dbt project defines the dimensional data warehouse (facts and dimensions), transformation logic, tests, and documentation that form the living analytical backbone of the platform.

--- a/dbt/README.pt-br.md
+++ b/dbt/README.pt-br.md
@@ -1,0 +1,3 @@
+Este diretório contém a camada de modelagem analítica da plataforma, implementada com dbt.
+
+O projeto dbt define o data warehouse dimensional (fatos e dimensões), as transformações, testes e documentação que compõem a base analítica viva da plataforma.

--- a/scripts/ingestion/README.md
+++ b/scripts/ingestion/README.md
@@ -1,4 +1,3 @@
-# Ingestion Scripts
+This directory contains ingestion and loading scripts responsible for bringing external data into the platform.
 
-Utility scripts for ingesting raw data into the data lake and BigQuery.
-These scripts are versioned for reproducibility but are not production pipelines.
+These scripts represent the first operational step of the analytical lifecycle, transforming external datasets (such as public CSV files) into reproducible and structured inputs for the data lake.

--- a/scripts/ingestion/README.pt-br.md
+++ b/scripts/ingestion/README.pt-br.md
@@ -1,0 +1,3 @@
+Este diretório contém os scripts de ingestão e carga responsáveis por trazer dados externos para a plataforma.
+
+Esses scripts representam o primeiro passo operacional do ciclo analítico, transformando fontes externas (como CSVs públicos) em insumos reproduzíveis para o data lake.


### PR DESCRIPTION
## O que mudou

Este PR reestrutura a documentação do repositório para refletir o projeto como uma plataforma analítica de longo prazo, e não como um conjunto de experimentos isolados.

As mudanças são exclusivamente de documentação e não afetam código, modelos ou pipelines de dados.

## Principais melhorias

- Inclusão de um caminho de leitura claro no README raiz para orientar quem acessa o repositório pela primeira vez
- Posicionamento explícito do data warehouse como fundação analítica da plataforma
- Clareza sobre o papel de cada diretório do core (data lake, ingestão, dbt)
- Enquadramento do projeto de territorialização partidária como um produto analítico entregue
- Adição da seção "Estado atual e roadmap" para comunicar evolução contínua e direção do projeto
- Documentação disponível em inglês e português (PT-BR)

## Por que essa mudança

A documentação inicial foi criada em um momento de exploração e brainstorming.
Com a evolução do projeto para uma plataforma analítica coerente, tornou-se necessário alinhar a documentação com:
- a intenção arquitetural
- o pensamento de produto
- as decisões e trade-offs já consolidados

Este PR faz esse alinhamento.

## Escopo

- Apenas documentação
- Nenhuma alteração em código, modelos ou pipelines
